### PR TITLE
(security): re-enable antiforgery/CSRF protection

### DIFF
--- a/ODK.Web.Razor/Controllers/AccountController.cs
+++ b/ODK.Web.Razor/Controllers/AccountController.cs
@@ -161,6 +161,7 @@ public class AccountController : OdkControllerBase
     }
 
     [AllowAnonymous]
+    [IgnoreAntiforgeryToken] // token posted by Google Identity JS, not a first-party form; exempt for now
     [HttpPost("account/login/google")]
     public async Task<IActionResult> GoogleSiteLogin([FromForm] string token, string? returnUrl)
     {
@@ -199,6 +200,7 @@ public class AccountController : OdkControllerBase
     }
 
     [AllowAnonymous]
+    [IgnoreAntiforgeryToken] // token posted by Google Identity JS, not a first-party form; exempt for now (#3)
     [HttpPost("{chapterName}/account/login/google")]
     public async Task<IActionResult> GoogleChapterLogin(string chapterName, [FromForm] string token, string? returnUrl)
     {

--- a/ODK.Web.Razor/Controllers/ScheduledTasksController.cs
+++ b/ODK.Web.Razor/Controllers/ScheduledTasksController.cs
@@ -11,6 +11,7 @@ namespace ODK.Web.Razor.Controllers;
 
 [Route("[controller]")]
 [ApiController]
+[IgnoreAntiforgeryToken] // external cron POSTs; authenticated by the ScheduledTasks API key, not a token
 public class ScheduledTasksController : OdkControllerBase
 {
     private readonly IMemberAdminService _memberAdminService;

--- a/ODK.Web.Razor/Controllers/WebhooksController.cs
+++ b/ODK.Web.Razor/Controllers/WebhooksController.cs
@@ -15,6 +15,7 @@ using ODK.Web.Common.Services;
 namespace ODK.Web.Razor.Controllers;
 
 [ApiController]
+[IgnoreAntiforgeryToken] // external POSTs from Stripe/Brevo; authenticated by signature/secret, not a token
 public class WebhooksController : OdkControllerBase
 {
     private readonly AppSettings _appSettings;

--- a/ODK.Web.Razor/Pages/Account/Account.cshtml
+++ b/ODK.Web.Razor/Pages/Account/Account.cshtml
@@ -26,6 +26,7 @@
 
                 <section class="section">
                     <form action="/Account/PersonalDetails" method="post">
+                        @Html.AntiForgeryToken()
                         @await Html.PartialAsync("Account/_PersonalDetailsForm", new PersonalDetailsFormViewModel
                         {
                             EmailAddress = member.EmailAddress,

--- a/ODK.Web.Razor/Pages/Account/Create.cshtml
+++ b/ODK.Web.Razor/Pages/Account/Create.cshtml
@@ -18,7 +18,7 @@
     ContentFunc = 
         @<div>
             <form method="post" action="/account/create" enctype="multipart/form-data">
-                @*@Html.AntiForgeryToken()*@
+                @Html.AntiForgeryToken()
                 @await Html.PartialAsync("Account/_AccountCreateForm", new AccountCreateFormViewModel
                 {
                     GoogleClientId = viewModel.GoogleClientId,

--- a/ODK.Web.Razor/Pages/Account/Emails.cshtml
+++ b/ODK.Web.Razor/Pages/Account/Emails.cshtml
@@ -33,7 +33,7 @@
                 <section class="section">                                        
                     <h3 class="mb-3">Change email</h3>
                     <form method="post" action="/account/email/change">
-                        @*@Html.AntiForgeryToken()*@        
+                        @Html.AntiForgeryToken()        
     
                         @await Html.PartialAsync("Account/_ChangeEmailForm", new ChangeEmailFormViewModel
                         {

--- a/ODK.Web.Razor/Pages/Account/Groups.cshtml
+++ b/ODK.Web.Razor/Pages/Account/Groups.cshtml
@@ -66,6 +66,7 @@
                                         else
                                         {
                                             <form method="post" action="/groups/@chapter.Chapter.Id/leave">
+                                                @Html.AntiForgeryToken()
                                                 <button class="btn btn-danger btn-sm" onclick="return confirm('Are you sure you want to leave this group?');">
                                                     Leave
                                                 </button>

--- a/ODK.Web.Razor/Pages/Account/Location.cshtml
+++ b/ODK.Web.Razor/Pages/Account/Location.cshtml
@@ -28,7 +28,7 @@
             @<div>
                 <section class="section">
                     <form action="/account/location" method="post">
-                        @*@Html.AntiForgeryToken()*@
+                        @Html.AntiForgeryToken()
                         @await Html.PartialAsync("Account/_LocationForm", new LocationFormViewModel
                         {
                             DistanceUnit = viewModel.MemberPreferences?.DistanceUnit,

--- a/ODK.Web.Razor/Pages/Chapters/Account/Account.cshtml
+++ b/ODK.Web.Razor/Pages/Chapters/Account/Account.cshtml
@@ -29,6 +29,7 @@
 
                 <section class="section">
                     <form action="/Account/PersonalDetails" method="post">
+                        @Html.AntiForgeryToken()
                         @await Html.PartialAsync("Account/_PersonalDetailsForm", new PersonalDetailsFormViewModel
                         {
                             Chapter = chapter,

--- a/ODK.Web.Razor/Pages/Chapters/Account/Profile.cshtml
+++ b/ODK.Web.Razor/Pages/Chapters/Account/Profile.cshtml
@@ -37,7 +37,7 @@
             @<div>
                 <section class="section">
                     <form method="post" action="/groups/@viewModel.Chapter.Id/profile">
-                        @*@Html.AntiForgeryToken()*@
+                        @Html.AntiForgeryToken()
 
                         @await Html.PartialAsync("Account/_ChapterProfileForm", viewModel.ChapterProfile)
 

--- a/ODK.Web.Razor/Pages/My/Groups/Create.cshtml
+++ b/ODK.Web.Razor/Pages/My/Groups/Create.cshtml
@@ -51,7 +51,6 @@
             else
             {
                 <form method="post">
-                    @*@Html.AntiForgeryToken()*@
 
                     @await Html.PartialAsync("Groups/_GroupCreateForm", new CreateChapterFormViewModel
                     {

--- a/ODK.Web.Razor/Pages/Shared/_Layout.cshtml
+++ b/ODK.Web.Razor/Pages/Shared/_Layout.cshtml
@@ -8,6 +8,7 @@
 @using ODK.Web.Razor.Services
 @inject IOdkRoutes OdkRoutes
 @inject IRequestStore RequestStore
+@inject Microsoft.AspNetCore.Antiforgery.IAntiforgery Antiforgery
 @{
     var (platform, chapter, currentMember) = 
         (RequestStore.Platform, RequestStore.ChapterOrDefault, RequestStore.CurrentMemberOrDefault);
@@ -73,6 +74,8 @@
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    @* Antiforgery request token for AJAX POSTs - read by odk.forms.js and sent as the RequestVerificationToken header. *@
+    <meta name="request-verification-token" content="@Antiforgery.GetAndStoreTokens(Context).RequestToken" />
     <title>@title</title>    
     @if (!string.IsNullOrEmpty(description))
     {

--- a/ODK.Web.Razor/Program.cs
+++ b/ODK.Web.Razor/Program.cs
@@ -163,10 +163,7 @@ public class Program
     {
         var builder = WebApplication.CreateBuilder(args);
 
-        builder.Services.AddRazorPages().AddRazorPagesOptions(o =>
-        {
-            o.Conventions.ConfigureFilter(new IgnoreAntiforgeryTokenAttribute());
-        });
+        builder.Services.AddRazorPages();
 
         builder.Services.AddControllers();
 
@@ -292,9 +289,15 @@ public class Program
 
     private static AppSettings ConfigureServices(IConfiguration config, IServiceCollection services)
     {
+        // Validate an antiforgery token on every unsafe request (POST/PUT/PATCH/DELETE), for both MVC
+        // controllers and Razor Page handlers. The header name lets AJAX POSTs send the token via header
+        // (see the request-verification-token meta tag in the layout). Endpoints that receive external
+        // POSTs (webhooks, scheduled-task cron, OAuth callbacks) opt out with [IgnoreAntiforgeryToken].
+        services.AddAntiforgery(options => options.HeaderName = "RequestVerificationToken");
+
         services
             .AddMemoryCache()
-            .AddControllers()
+            .AddControllers(options => options.Filters.Add<AutoValidateAntiforgeryTokenAttribute>())
             .AddJsonOptions(options =>
             {
                 options.JsonSerializerOptions.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;

--- a/ODK.Web.Razor/Views/Shared/Account/_ActivateContent.cshtml
+++ b/ODK.Web.Razor/Views/Shared/Account/_ActivateContent.cshtml
@@ -4,7 +4,7 @@
 <form method="post" action="@(Model.ChapterId != null ? $"/groups/{Model.ChapterId}" : "")/account/activate">
     @Html.HiddenFor(x => x.Token)
 
-    @*@Html.AntiForgeryToken()*@
+    @Html.AntiForgeryToken()
     <div class="form-group mb-3 required">
         @Html.LabelFor(x => x.Password, new { @class = "form-label" })
         @Html.PasswordFor(x => x.Password, new { @class = "form-control" })

--- a/ODK.Web.Razor/Views/Shared/Account/_ChangeEmailContent.cshtml
+++ b/ODK.Web.Razor/Views/Shared/Account/_ChangeEmailContent.cshtml
@@ -4,7 +4,7 @@
 @model ChapterAccountViewModel
 
 <form method="post" action="/@Model.Chapter.ShortName/account/email/change">
-    @*@Html.AntiForgeryToken()*@        
+    @Html.AntiForgeryToken()        
     
     @await Html.PartialAsync("Account/_ChangeEmailForm", new ChangeEmailFormViewModel
     {

--- a/ODK.Web.Razor/Views/Shared/Account/_ChangePasswordContent.cshtml
+++ b/ODK.Web.Razor/Views/Shared/Account/_ChangePasswordContent.cshtml
@@ -1,7 +1,7 @@
 ﻿@using ODK.Web.Razor.Models.Account
 
 <form method="post" action="/Account/Password/Change">
-    @*@Html.AntiForgeryToken()*@
+    @Html.AntiForgeryToken()
     @await Html.PartialAsync("Account/_ChangePasswordForm", new ChangePasswordFormViewModel())
     <button type="submit" class="btn btn-primary">Update</button>
 </form>

--- a/ODK.Web.Razor/Views/Shared/Account/_ChapterJoinContent.cshtml
+++ b/ODK.Web.Razor/Views/Shared/Account/_ChapterJoinContent.cshtml
@@ -15,7 +15,6 @@
 }
 
 <form method="post" enctype="multipart/form-data">
-    @*@Html.AntiForgeryToken()*@
     
     @if (memberId == null)
     {

--- a/ODK.Web.Razor/Views/Shared/Account/_ChapterLoginContent.cshtml
+++ b/ODK.Web.Razor/Views/Shared/Account/_ChapterLoginContent.cshtml
@@ -7,7 +7,7 @@
 <hr/>
 
 <form action="/@Model.Chapter?.ShortName/account/login/google" method="post" data-oauth-submit>
-    @*@Html.AntiForgeryToken()*@
+    @Html.AntiForgeryToken()
     <input type="hidden" name="token" data-oauth-token />
     @await Html.PartialAsync("Components/_GoogleLoginButton", new GoogleLoginButtonViewModel
     {

--- a/ODK.Web.Razor/Views/Shared/Account/_ChapterSubscriptionContent.cshtml
+++ b/ODK.Web.Razor/Views/Shared/Account/_ChapterSubscriptionContent.cshtml
@@ -82,6 +82,7 @@ else
 
     <div>
         <form action="/chapters/@Model.Chapter.Id/account/subscription/cancel" method="post">
+            @Html.AntiForgeryToken()
             <input type="hidden" name="@nameof(CancelSubscriptionRequest.ExternalId)" value="@Model.ExternalSubscription.ExternalId" />
             <button class="btn btn-danger" onclick="return confirm('Are you sure you want to cancel your subscription?');">
                 Cancel subscription

--- a/ODK.Web.Razor/Views/Shared/Account/_DeleteAccountContent.cshtml
+++ b/ODK.Web.Razor/Views/Shared/Account/_DeleteAccountContent.cshtml
@@ -30,6 +30,7 @@ else
     </p>
 
     <form method="post" action="/account/delete">
+        @Html.AntiForgeryToken()
         <button type="submit" class="btn btn-danger" onclick="return confirm('Are you sure you want to delete your account?');">
             Delete my account
         </button>

--- a/ODK.Web.Razor/Views/Shared/Account/_EmailPreferencesContent.cshtml
+++ b/ODK.Web.Razor/Views/Shared/Account/_EmailPreferencesContent.cshtml
@@ -26,7 +26,7 @@
 <p>Choose whether or not you want to receive the following emails:</p>
 
 <form action="/account/emails" method="post">
-    @*@Html.AntiForgeryToken()*@
+    @Html.AntiForgeryToken()
     @await Html.PartialAsync("Account/_EmailPreferencesForm", new EmailPreferencesFormViewModel
     {
         Preferences = preferenceViewModels

--- a/ODK.Web.Razor/Views/Shared/Account/_ForgottenPasswordForm.cshtml
+++ b/ODK.Web.Razor/Views/Shared/Account/_ForgottenPasswordForm.cshtml
@@ -5,7 +5,7 @@
 </p>
 
 <form method="post" action="@(Model.Chapter != null ? $"/{Model.Chapter.Id}" : "")/Account/Password/Forgotten">
-    @*@Html.AntiForgeryToken()*@
+    @Html.AntiForgeryToken()
     
     <div class="form-group mb-3 required">
         @Html.LabelFor(x => x.EmailAddress, new { @class = "form-label" })

--- a/ODK.Web.Razor/Views/Shared/Account/_InterestsContent.cshtml
+++ b/ODK.Web.Razor/Views/Shared/Account/_InterestsContent.cshtml
@@ -3,7 +3,7 @@
 @model MemberInterestsPageViewModel
 
 <form action="/account/topics" method="post">
-    @*@Html.AntiForgeryToken()*@
+    @Html.AntiForgeryToken()
     <div class="form-group mb-3">
         <p>
             We use your interests to help you find groups relevant to you

--- a/ODK.Web.Razor/Views/Shared/Account/_LoginForm.cshtml
+++ b/ODK.Web.Razor/Views/Shared/Account/_LoginForm.cshtml
@@ -4,7 +4,7 @@
 @inject IOdkRoutes OdkRoutes
 
 <form method="post" action="@(Model.Chapter != null ? $"/{Model.Chapter.ShortName}" : "")/Account/Login?ReturnUrl=@Model.ReturnUrl">
-    @*@Html.AntiForgeryToken()*@
+    @Html.AntiForgeryToken()
 
     <div class="form-group required mb-3">
         @Html.LabelFor(x => x.Email, new { @class = "form-label" })

--- a/ODK.Web.Razor/Views/Shared/Account/_ResetPasswordForm.cshtml
+++ b/ODK.Web.Razor/Views/Shared/Account/_ResetPasswordForm.cshtml
@@ -1,7 +1,6 @@
 ﻿@model ODK.Web.Razor.Models.Account.ResetPasswordFormViewModel
 
 <form method="post">
-    @*@Html.AntiForgeryToken()*@
     
     @Html.HiddenFor(x => x.Token)
     <div class="form-group mb-3 required">

--- a/ODK.Web.Razor/Views/Shared/Account/_SiteLoginContent.cshtml
+++ b/ODK.Web.Razor/Views/Shared/Account/_SiteLoginContent.cshtml
@@ -7,7 +7,7 @@
 <hr/>
 
 <form action="/account/login/google" method="post" data-oauth-submit>
-    @*@Html.AntiForgeryToken()*@
+    @Html.AntiForgeryToken()
     <input type="hidden" name="token" data-oauth-token />
     @await Html.PartialAsync("Components/_GoogleLoginButton", new GoogleLoginButtonViewModel
     {

--- a/ODK.Web.Razor/Views/Shared/Account/_SiteSubscriptionContent.cshtml
+++ b/ODK.Web.Razor/Views/Shared/Account/_SiteSubscriptionContent.cshtml
@@ -32,7 +32,7 @@
         .ToArray();
 
     <form action="/account/currency" method="post">
-        @*@Html.AntiForgeryToken()*@
+        @Html.AntiForgeryToken()
         <div class="form-group mb-3 required">
             @Html.Label("currencyId", "Choose currency", new { @class = "form-label" })
             @Html.DropDownList("currencyId", currencyOptions, "", new 

--- a/ODK.Web.Razor/Views/Shared/Account/_UpdatePictureContent.cshtml
+++ b/ODK.Web.Razor/Views/Shared/Account/_UpdatePictureContent.cshtml
@@ -20,6 +20,7 @@
             </button>
 
             <form class="d-flex align-items-center" method="post" action="/account/picture/rotate">
+                @Html.AntiForgeryToken()
                 <button class="btn-icon" data-bs-toggle="tooltip" data-bs-title="Rotate">
                     @await Html.PartialAsync("Components/_Icon", new IconViewModel(IconType.Undo)
                     {
@@ -39,7 +40,7 @@
     Body =
     @<div>
         <form method="post" action="/account/picture/change">
-            @*@Html.AntiForgeryToken()*@
+            @Html.AntiForgeryToken()
             
             @await Html.PartialAsync("Account/_PictureUpload", new PictureUploadViewModel())
 

--- a/ODK.Web.Razor/Views/Shared/Admin/Chapter/Conversations/_ConversationContent.cshtml
+++ b/ODK.Web.Razor/Views/Shared/Admin/Chapter/Conversations/_ConversationContent.cshtml
@@ -50,7 +50,7 @@
                         @if (Model.CanReply)
                         {
                             <form action="/admin/groups/@Model.Chapter.Id/conversations/@Model.Conversation.Id/reply" method="post">
-                                @*@Html.AntiForgeryToken()*@
+                                @Html.AntiForgeryToken()
                                 @await Html.PartialAsync("Admin/Chapter/Conversations/_ConversationReplyForm", 
                                     new ChapterConversationReplyFormViewModel())
                                 <button class="btn btn-primary">Send</button>

--- a/ODK.Web.Razor/Views/Shared/Admin/Chapter/_DeleteContent.cshtml
+++ b/ODK.Web.Razor/Views/Shared/Admin/Chapter/_DeleteContent.cshtml
@@ -11,6 +11,7 @@
     </p>
 
     <form action="/groups/@Model.Chapter.Id/delete" method="post">
+        @Html.AntiForgeryToken()
         <button class="btn btn-danger" onclick="return confirm('Are you sure you want to delete this group?');">Delete</button>
     </form>
 }

--- a/ODK.Web.Razor/Views/Shared/Admin/Chapter/_EmailContent.cshtml
+++ b/ODK.Web.Razor/Views/Shared/Admin/Chapter/_EmailContent.cshtml
@@ -17,7 +17,6 @@ else
 }
 
 <form method="post">
-    @*@Html.AntiForgeryToken()*@
     @await Html.PartialAsync("Admin/Chapter/_EmailForm", new ChapterEmailFormViewModel
     {
         Content = Model.Email.HtmlContent,
@@ -41,8 +40,10 @@ else
 
 <form method="post" action="/groups/@Model.Chapter.Id/emails/@Model.Email.Type/test"
       id="send-test-form">
+    @Html.AntiForgeryToken()
 </form>
 
 <form method="post" action="/groups/@Model.Chapter.Id/emails/@Model.Email.Type/restoreDefault"
       id="restore-default-form">
+    @Html.AntiForgeryToken()
 </form>

--- a/ODK.Web.Razor/Views/Shared/Admin/Chapter/_ImageContent.cshtml
+++ b/ODK.Web.Razor/Views/Shared/Admin/Chapter/_ImageContent.cshtml
@@ -4,7 +4,7 @@
 @model ChapterImageAdminPageViewModel
 
 <form action="/groups/@Model.Chapter.Id/image" method="post">
-    @*@Html.AntiForgeryToken()*@
+    @Html.AntiForgeryToken()
     @await Html.PartialAsync("Admin/Chapter/_ImageForm", new ChapterImageFormViewModel
     {
         ChapterImage = Model.Image

--- a/ODK.Web.Razor/Views/Shared/Admin/Chapter/_LinksContent.cshtml
+++ b/ODK.Web.Razor/Views/Shared/Admin/Chapter/_LinksContent.cshtml
@@ -4,7 +4,7 @@
 @model ChapterLinksAdminPageViewModel
 
 <form action="/groups/@Model.Chapter.Id/links" method="post">
-    @*@Html.AntiForgeryToken()*@
+    @Html.AntiForgeryToken()
     @await Html.PartialAsync("Admin/Chapter/_LinksForm", new ChapterLinksFormViewModel
     {
         Chapter = Model.Chapter,

--- a/ODK.Web.Razor/Views/Shared/Admin/Chapter/_LocationContent.cshtml
+++ b/ODK.Web.Razor/Views/Shared/Admin/Chapter/_LocationContent.cshtml
@@ -10,7 +10,7 @@
 
 <section class="section--admin">        
     <form action="/groups/@Model.Chapter.Id/location" method="post">        
-        @*@Html.AntiForgeryToken()*@                
+        @Html.AntiForgeryToken()                
         @if (Model.Country != null)
         {
             <div class="form-group mb-3">

--- a/ODK.Web.Razor/Views/Shared/Admin/Chapter/_MessageContent.cshtml
+++ b/ODK.Web.Razor/Views/Shared/Admin/Chapter/_MessageContent.cshtml
@@ -72,7 +72,7 @@
             <button type="button" class="btn btn-link" data-bs-toggle="collapse" data-bs-target="#mark-replied">Already replied?</button>
             <div class="collapse" id="mark-replied">
                 <form action="/groups/@Model.Chapter.Id/messages/@Model.Message.Id/replied" method="post">
-                    @*@Html.AntiForgeryToken()*@
+                    @Html.AntiForgeryToken()
                     <button class="btn btn-primary">Set message as replied</button>
                 </form>
             </div>            
@@ -80,7 +80,7 @@
     }    
 
     <form action="/groups/@Model.Chapter.Id/messages/@Model.Message.Id/reply" method="post">
-        @*@Html.AntiForgeryToken()*@
+        @Html.AntiForgeryToken()
         @await Html.PartialAsync("Admin/Chapter/_MessageForm", new ChapterMessageReplyFormViewModel
         {
             Message = ""

--- a/ODK.Web.Razor/Views/Shared/Admin/Chapter/_MessagesContent.cshtml
+++ b/ODK.Web.Razor/Views/Shared/Admin/Chapter/_MessagesContent.cshtml
@@ -52,7 +52,7 @@
                     </td>
                     <td>
                         <form method="post" action="/groups/@Model.Chapter.Id/messages/@message.Id/delete">
-                            @*@Html.AntiForgeryToken()*@
+                            @Html.AntiForgeryToken()
                             <button data-bs-toggle="tooltip" data-bs-title="Delete" class="btn-icon text-danger"
                                     onclick="return confirm('Are you sure you want to delete this message?');">
                                 @await Html.PartialAsync("Components/_Icon", new IconViewModel(IconType.Times))

--- a/ODK.Web.Razor/Views/Shared/Admin/Chapter/_PagesContent.cshtml
+++ b/ODK.Web.Razor/Views/Shared/Admin/Chapter/_PagesContent.cshtml
@@ -7,7 +7,7 @@
 @model ChapterPagesAdminPageViewModel
 
 <form action="/groups/@Model.Chapter.Id/pages" method="post">
-    @*@Html.AntiForgeryToken()*@
+    @Html.AntiForgeryToken()
     @await Html.PartialAsync("Admin/Chapter/_PagesForm", new ChapterPagesFormViewModel
     {
         Pages = Model.ChapterPages

--- a/ODK.Web.Razor/Views/Shared/Admin/Chapter/_PrivacyContent.cshtml
+++ b/ODK.Web.Razor/Views/Shared/Admin/Chapter/_PrivacyContent.cshtml
@@ -8,7 +8,7 @@
 @model ChapterPrivacyAdminPageViewModel
 
 <form action="/groups/@Model.Chapter.Id/privacy" method="post">
-    @*@Html.AntiForgeryToken()*@
+    @Html.AntiForgeryToken()
     @await Html.PartialAsync("Admin/Chapter/_PrivacyForm", new ChapterPrivacySettingsFormViewModel
     {
         EventResponseVisibility = Model.PrivacySettings.Visibility(ChapterFeatureType.EventResponses),

--- a/ODK.Web.Razor/Views/Shared/Admin/Chapter/_PropertiesContent.cshtml
+++ b/ODK.Web.Razor/Views/Shared/Admin/Chapter/_PropertiesContent.cshtml
@@ -47,13 +47,13 @@
                     <td>
                         <div class="d-flex">
                             <form method="post" action="/groups/@Model.Chapter.Id/properties/@property.Id/move/up">
-                                @*@Html.AntiForgeryToken()*@
+                                @Html.AntiForgeryToken()
                                 <button data-bs-toggle="tooltip" data-bs-title="Move up" class="btn btn-icon text-secondary">
                                     @await Html.PartialAsync("Components/_Icon", new IconViewModel(IconType.ArrowCircleUp))
                                 </button>
                             </form>
                             <form method="post" action="/groups/@Model.Chapter.Id/properties/@property.Id/move/down">
-                                @*@Html.AntiForgeryToken()*@
+                                @Html.AntiForgeryToken()
                                 <button data-bs-toggle="tooltip" data-bs-title="Move down" class="btn btn-icon text-secondary">
                                     @await Html.PartialAsync("Components/_Icon", new IconViewModel(IconType.ArrowCircleDown))
                                 </button>
@@ -62,7 +62,7 @@
                     </td>
                     <td>
                         <form method="post" action="/groups/@Model.Chapter.Id/properties/@property.Id/delete">
-                            @*@Html.AntiForgeryToken()*@
+                            @Html.AntiForgeryToken()
                             <button data-bs-toggle="tooltip" data-bs-title="Delete" class="btn-icon text-danger"
                                     onclick="return confirm('Are you sure you want to delete this question?');">
                                 @await Html.PartialAsync("Components/_Icon", new IconViewModel(IconType.Times))

--- a/ODK.Web.Razor/Views/Shared/Admin/Chapter/_PropertyCreateContent.cshtml
+++ b/ODK.Web.Razor/Views/Shared/Admin/Chapter/_PropertyCreateContent.cshtml
@@ -2,7 +2,6 @@
 @using ODK.Web.Razor.Models.Admin.Chapters
 
 <form method="post">
-    @*@Html.AntiForgeryToken()*@
     @await Html.PartialAsync("Admin/Chapter/_PropertyForm", new ChapterPropertyFormViewModel
     {
         DataType = DataType.Text,

--- a/ODK.Web.Razor/Views/Shared/Admin/Chapter/_PropertyEditContent.cshtml
+++ b/ODK.Web.Razor/Views/Shared/Admin/Chapter/_PropertyEditContent.cshtml
@@ -6,7 +6,6 @@
 @model ChapterPropertyAdminPageViewModel
 
 <form method="post">
-    @*@Html.AntiForgeryToken()*@
     @await Html.PartialAsync("Admin/Chapter/_PropertyForm", new ChapterPropertyFormViewModel
     {
         ApplicationOnly = Model.Property.ApplicationOnly,

--- a/ODK.Web.Razor/Views/Shared/Admin/Chapter/_QuestionCreateContent.cshtml
+++ b/ODK.Web.Razor/Views/Shared/Admin/Chapter/_QuestionCreateContent.cshtml
@@ -1,7 +1,6 @@
 ﻿@using ODK.Web.Razor.Models.Admin.Chapters
 
 <form method="post">
-    @*@Html.AntiForgeryToken()*@
     @await Html.PartialAsync("Admin/Chapter/_QuestionForm", new ChapterQuestionFormViewModel())
     <button class="btn btn-primary">Create</button>
 </form>

--- a/ODK.Web.Razor/Views/Shared/Admin/Chapter/_QuestionEditContent.cshtml
+++ b/ODK.Web.Razor/Views/Shared/Admin/Chapter/_QuestionEditContent.cshtml
@@ -7,7 +7,7 @@
 @model ChapterQuestionAdminPageViewModel
 
 <form method="post" action="/admin/groups/@Model.Chapter.Id/questions/@Model.Question.Id">
-    @*@Html.AntiForgeryToken()*@
+    @Html.AntiForgeryToken()
     @await Html.PartialAsync("Admin/Chapter/_QuestionForm", new ChapterQuestionFormViewModel
     {
         Answer = Model.Question.Answer,

--- a/ODK.Web.Razor/Views/Shared/Admin/Chapter/_QuestionsContent.cshtml
+++ b/ODK.Web.Razor/Views/Shared/Admin/Chapter/_QuestionsContent.cshtml
@@ -57,13 +57,13 @@ else
                         <td>
                             <div class="d-flex">
                                 <form method="post" action="/groups/@Model.Chapter.Id/questions/@question.Id/move/up">
-                                    @*@Html.AntiForgeryToken()*@
+                                    @Html.AntiForgeryToken()
                                     <button data-bs-toggle="tooltip" data-bs-title="Move up" class="btn btn-icon text-secondary">
                                         @await Html.PartialAsync("Components/_Icon", new IconViewModel(IconType.ArrowCircleUp))
                                     </button>
                                 </form>
                                 <form method="post" action="/groups/@Model.Chapter.Id/questions/@question.Id/move/down">
-                                    @*@Html.AntiForgeryToken()*@
+                                    @Html.AntiForgeryToken()
                                     <button data-bs-toggle="tooltip" data-bs-title="Move down" class="btn btn-icon text-secondary">
                                         @await Html.PartialAsync("Components/_Icon", new IconViewModel(IconType.ArrowCircleDown))
                                     </button>
@@ -72,7 +72,7 @@ else
                         </td>
                         <td>
                             <form method="post" action="/groups/@Model.Chapter.Id/questions/@question.Id/delete">
-                                @*@Html.AntiForgeryToken()*@
+                                @Html.AntiForgeryToken()
                                 <button data-bs-toggle="tooltip" data-bs-title="Delete" class="btn-icon text-danger"
                                         onclick="return confirm('Are you sure you want to delete this question?');">
                                     @await Html.PartialAsync("Components/_Icon", new IconViewModel(IconType.Times))

--- a/ODK.Web.Razor/Views/Shared/Admin/Chapter/_TextContent.cshtml
+++ b/ODK.Web.Razor/Views/Shared/Admin/Chapter/_TextContent.cshtml
@@ -8,7 +8,7 @@
 @model ChapterTextsAdminPageViewModel
 
 <form method="post" action="/groups/@Model.Chapter.Id/texts">
-    @*@Html.AntiForgeryToken()*@
+    @Html.AntiForgeryToken()
 
     @await Html.PartialAsync("Admin/Chapter/_TextForm", new ChapterTextsFormViewModel
     {

--- a/ODK.Web.Razor/Views/Shared/Admin/Chapter/_ThemeContent.cshtml
+++ b/ODK.Web.Razor/Views/Shared/Admin/Chapter/_ThemeContent.cshtml
@@ -3,7 +3,7 @@
 @model Chapter
 
 <form method="post" action="/groups/@Model.Id/theme">
-    @*@Html.AntiForgeryToken()*@
+    @Html.AntiForgeryToken()
 
     @await Html.PartialAsync("Admin/Chapter/_ThemeForm", new ThemeFormViewModel
     {

--- a/ODK.Web.Razor/Views/Shared/Admin/Chapter/_TopicsContent.cshtml
+++ b/ODK.Web.Razor/Views/Shared/Admin/Chapter/_TopicsContent.cshtml
@@ -4,6 +4,7 @@
 @model ChapterTopicsAdminPageViewModel
 
 <form action="/admin/groups/@Model.Chapter.Id/topics" method="post">
+    @Html.AntiForgeryToken()
     <div class="form-group mb-3">
         @await Html.PartialAsync("Topics/_TopicPicker", new TopicPickerViewModel
         {

--- a/ODK.Web.Razor/Views/Shared/Admin/Events/Event/_EventCommentsContent.cshtml
+++ b/ODK.Web.Razor/Views/Shared/Admin/Events/Event/_EventCommentsContent.cshtml
@@ -57,6 +57,7 @@
                         @if (!comment.Hidden)
                         {
                             <form method="post" action="/groups/@Model.Chapter.Id/events/@Model.Event.Id/comments/@comment.Id/hide">
+                                @Html.AntiForgeryToken()
                                 <button class="btn btn-outline-danger btn-sm" onclick="return confirm('Are you sure you want to hide this comment?');">
                                     Hide
                                 </button>
@@ -65,6 +66,7 @@
                         else
                         {
                             <form method="post" action="/groups/@Model.Chapter.Id/events/@Model.Event.Id/comments/@comment.Id/show">
+                                @Html.AntiForgeryToken()
                                 <button class="btn btn-outline-success btn-sm" onclick="return confirm('Are you sure you want to show this comment?');">
                                     Show
                                 </button>

--- a/ODK.Web.Razor/Views/Shared/Admin/Events/Event/_EventContent.cshtml
+++ b/ODK.Web.Razor/Views/Shared/Admin/Events/Event/_EventContent.cshtml
@@ -21,7 +21,7 @@
 @if (Model.Event.PublishedUtc == null)
 {
     <form action="/groups/@Model.Chapter.Id/events/@Model.Event.Id/publish" method="post">
-        @*@Html.AntiForgeryToken()*@
+        @Html.AntiForgeryToken()
         <div class="mb-3">
             <button class="btn btn-primary" type="submit">
                 @await Html.PartialAsync("Components/_Icon", new IconViewModel(IconType.Upload))
@@ -32,7 +32,6 @@
 }
 
 <form method="post">
-    @*@Html.AntiForgeryToken()*@    
     @await Html.PartialAsync("Admin/Events/Event/_EventForm", new EventFormViewModel
     {
         AttendeeLimit = Model.Event.AttendeeLimit,
@@ -70,4 +69,5 @@
 
 <form method="post" action="/groups/@Model.Chapter.Id/events/@Model.Event.Id/delete"
       id="event-delete-form">
+    @Html.AntiForgeryToken()
 </form>

--- a/ODK.Web.Razor/Views/Shared/Admin/Events/Event/_EventInviteeUpdate.cshtml
+++ b/ODK.Web.Razor/Views/Shared/Admin/Events/Event/_EventInviteeUpdate.cshtml
@@ -6,7 +6,7 @@
 
 <h4>Send update</h4>
 <form method="post" action="/groups/@Model.Chapter.Id/events/@Model.EventId/invites/send/update">
-    @*@Html.AntiForgeryToken()*@
+    @Html.AntiForgeryToken()
     
     <div class="form-group mb-3 required">
         @Html.LabelFor(x => x.ResponseTypes, new { @class = "form-label" })

--- a/ODK.Web.Razor/Views/Shared/Admin/Events/Event/_EventInvitesContent.cshtml
+++ b/ODK.Web.Razor/Views/Shared/Admin/Events/Event/_EventInvitesContent.cshtml
@@ -34,14 +34,14 @@
     <div>
         <div class="d-flex gap-3">
             <form method="post" action="/groups/@Model.Chapter.Id/events/@Model.Event.Id/invites/send">
-                @*@Html.AntiForgeryToken()*@
+                @Html.AntiForgeryToken()
                 <button type="submit" class="btn btn-success"
                         onclick="return confirm('Are you sure you want to send invite emails for this event?');">
                     Send invites
                 </button>
             </form>
             <form method="post" action="/groups/@Model.Chapter.Id/events/@Model.Event.Id/invites/send/test">
-                @*@Html.AntiForgeryToken()*@
+                @Html.AntiForgeryToken()
                 <button type="submit" class="btn btn-secondary">Send test</button>
             </form>
         </div>        

--- a/ODK.Web.Razor/Views/Shared/Admin/Events/Event/_EventResponsesContent.cshtml
+++ b/ODK.Web.Razor/Views/Shared/Admin/Events/Event/_EventResponsesContent.cshtml
@@ -128,7 +128,7 @@
                                             var active = response == responseType;
 
                                             <form method="post" action="/groups/@Model.Chapter.Id/events/@Model.Event.Id/attendees/@member.Id">
-                                                @*@Html.AntiForgeryToken()*@
+                                                @Html.AntiForgeryToken()
                                                 @await Html.PartialAsync("Events/_EventResponseIcon", new EventResponseIconViewModel
                                                 {
                                                     Active = active,

--- a/ODK.Web.Razor/Views/Shared/Admin/Events/Event/_ScheduledEmailForm.cshtml
+++ b/ODK.Web.Razor/Views/Shared/Admin/Events/Event/_ScheduledEmailForm.cshtml
@@ -4,7 +4,7 @@
 @model ODK.Web.Razor.Models.Admin.Events.EventScheduledEmailFormViewModel
 
 <form method="post" action="/groups/@Model.Chapter.Id/events/@Model.EventId/invites/scheduled">
-    @*@Html.AntiForgeryToken()*@
+    @Html.AntiForgeryToken()
 
     <div class="form-group mb-3">        
         <div class="row">

--- a/ODK.Web.Razor/Views/Shared/Admin/Events/_EventCreateContent.cshtml
+++ b/ODK.Web.Razor/Views/Shared/Admin/Events/_EventCreateContent.cshtml
@@ -22,7 +22,6 @@
 @if (Model.Venues.Count > 0)
 {
     <form method="post">
-        @*@Html.AntiForgeryToken()*@
 
         @await Html.PartialAsync("Admin/Events/Event/_EventForm", new EventFormViewModel
         {

--- a/ODK.Web.Razor/Views/Shared/Admin/Events/_SettingsContent.cshtml
+++ b/ODK.Web.Razor/Views/Shared/Admin/Events/_SettingsContent.cshtml
@@ -13,7 +13,7 @@
 @model EventSettingsAdminPageViewModel
 
 <form action="/groups/@Model.Chapter.Id/events/settings" method="post">
-    @*@Html.AntiForgeryToken()*@
+    @Html.AntiForgeryToken()
     @await Html.PartialAsync("Admin/Events/_SettingsForm", new EventSettingsFormViewModel
     {
         DefaultDayOfWeek = Model.Settings?.DefaultDayOfWeek,

--- a/ODK.Web.Razor/Views/Shared/Admin/Members/_AdminMemberContent.cshtml
+++ b/ODK.Web.Razor/Views/Shared/Admin/Members/_AdminMemberContent.cshtml
@@ -8,7 +8,6 @@
 @model AdminMemberAdminPageViewModel
 
 <form method="post">
-    @*@Html.AntiForgeryToken()*@
     <fieldset disabled="@(Model.ReadOnly ? "" : null)">
         @await Html.PartialAsync("Admin/Members/_AdminMemberForm", new AdminMemberFormViewModel
         {

--- a/ODK.Web.Razor/Views/Shared/Admin/Members/_AdminMembersContent.cshtml
+++ b/ODK.Web.Razor/Views/Shared/Admin/Members/_AdminMembersContent.cshtml
@@ -43,7 +43,7 @@
             @<div>
                 <form method="post" action="/groups/@Model.Chapter.Id/members/admins"
                       class="row g-3 mb-3">
-                    @*@Html.AntiForgeryToken()*@
+                    @Html.AntiForgeryToken()
                     <div class="col-lg-6 col-12 d-flex gap-1">
                         <div class="flex-grow-1">
                             @await Html.PartialAsync("Admin/Members/_AdminMemberAddForm", new AdminMemberAddFormViewModel
@@ -110,6 +110,7 @@
                                     @if (Model.Chapter.OwnerId != adminMember.MemberId)
                                     {
                                         <form method="post" action="/groups/@Model.Chapter.Id/members/admins/@member.Id/delete">
+                                            @Html.AntiForgeryToken()
                                             <button data-bs-toggle="tooltip" data-bs-title="Remove"
                                                     class="btn-icon text-danger"
                                                     onclick="return confirm('Are you sure you want to remove admin access for this member?');">

--- a/ODK.Web.Razor/Views/Shared/Admin/Members/_ApprovalsContent.cshtml
+++ b/ODK.Web.Razor/Views/Shared/Admin/Members/_ApprovalsContent.cshtml
@@ -50,7 +50,7 @@
                             </td>
                             <td>
                                 <form action="/groups/@Model.Chapter.Id/members/@member.Id/approve" method="post">
-                                    @*@Html.AntiForgeryToken()*@
+                                    @Html.AntiForgeryToken()
                                     <button class="btn btn-success">Approve</button>
                                 </form>
                             </td>

--- a/ODK.Web.Razor/Views/Shared/Admin/Members/_BulkEmailContent.cshtml
+++ b/ODK.Web.Razor/Views/Shared/Admin/Members/_BulkEmailContent.cshtml
@@ -14,7 +14,7 @@
     Feature = SiteFeatureType.SendMemberEmails,
     ContentFunc = 
         @<form method="post" action="/groups/@Model.Chapter.Id/members/email" data-live-url-container>
-            @*@Html.AntiForgeryToken()*@
+            @Html.AntiForgeryToken()
 
             <p>
                 <div class="row row-cols-lg-auto g-3 align-items-center">

--- a/ODK.Web.Razor/Views/Shared/Admin/Members/_ChapterSubscriptionCreateContent.cshtml
+++ b/ODK.Web.Razor/Views/Shared/Admin/Members/_ChapterSubscriptionCreateContent.cshtml
@@ -29,7 +29,6 @@
                 else
                 {
                     <form method="post">
-                        @*@Html.AntiForgeryToken()*@
                         @await Html.PartialAsync("Admin/Members/_SubscriptionForm", new SubscriptionFormViewModel
                         {
                             Currency = Model.Currency,

--- a/ODK.Web.Razor/Views/Shared/Admin/Members/_ImportMembersReview.cshtml
+++ b/ODK.Web.Razor/Views/Shared/Admin/Members/_ImportMembersReview.cshtml
@@ -78,6 +78,7 @@
     </ul>
 
     <form method="post" action="/groups/@Model.Chapter.Id/members/import">
+        @Html.AntiForgeryToken()
         @Html.HiddenFor(x => x.Token)
 
         <button type="submit" class="btn btn-primary">

--- a/ODK.Web.Razor/Views/Shared/Admin/Members/_MemberContent.cshtml
+++ b/ODK.Web.Razor/Views/Shared/Admin/Members/_MemberContent.cshtml
@@ -12,7 +12,6 @@
 @await Html.PartialAsync("Admin/Members/_MemberAdminTabs", Model)
 
 <form method="post">
-    @*@Html.AntiForgeryToken()*@
     @await Html.PartialAsync("Admin/Members/_MemberForm", new MemberFormViewModel
     {
         SubscriptionExpiryDate = Model.Subscription?.ExpiresUtc,

--- a/ODK.Web.Razor/Views/Shared/Admin/Members/_MemberConversationsContent.cshtml
+++ b/ODK.Web.Razor/Views/Shared/Admin/Members/_MemberConversationsContent.cshtml
@@ -66,7 +66,7 @@
                 BodyContentFunc = 
                     @<div>
                         <form action="/admin/groups/@Model.Chapter.Id/conversations" method="post">
-                            @*@Html.AntiForgeryToken()*@
+                            @Html.AntiForgeryToken()
                 @Html.Hidden(nameof(ChapterAdminStartConversationFormViewModel.MemberId), Model.Member.Id)
                             @await Html.PartialAsync("Contact/_ConversationForm", new ConversationFormViewModel())
                             <button class="btn btn-primary">Send</button>
@@ -87,7 +87,7 @@ else
             ContentFunc = 
                 @<div>
                     <form action="/admin/groups/@Model.Chapter.Id/conversations" method="post">
-                        @*@Html.AntiForgeryToken()*@
+                        @Html.AntiForgeryToken()
                         @Html.Hidden(nameof(ChapterAdminStartConversationFormViewModel.MemberId), Model.Member.Id)
                         @await Html.PartialAsync("Contact/_ConversationForm", new ConversationFormViewModel())
                         <button class="btn btn-primary">Send</button>

--- a/ODK.Web.Razor/Views/Shared/Admin/Members/_MemberDeleteContent.cshtml
+++ b/ODK.Web.Razor/Views/Shared/Admin/Members/_MemberDeleteContent.cshtml
@@ -6,7 +6,7 @@
 @await Html.PartialAsync("Admin/Members/_MemberAdminTabs", Model)
 
 <form method="post" action="/groups/@Model.Chapter.Id/members/@Model.Member.Id/delete">
-    @*@Html.AntiForgeryToken()*@
+    @Html.AntiForgeryToken()
     
     @if (Model.MemberSubscription?.Type.IsPaid() == true && Model.MemberSubscription?.IsExpired() == false)
     {

--- a/ODK.Web.Razor/Views/Shared/Admin/Members/_MemberImageContent.cshtml
+++ b/ODK.Web.Razor/Views/Shared/Admin/Members/_MemberImageContent.cshtml
@@ -19,7 +19,7 @@
         Only use for fixing squished images
     </div>
     <form action="/groups/@Model.Chapter.Id/members/@Model.Member.Id/picture" method="post">
-        @*@Html.AntiForgeryToken()*@
+        @Html.AntiForgeryToken()
         <div class="form-group mb-3">
             @await Html.PartialAsync("Account/_PictureUpload", new PictureUploadViewModel())
         </div>

--- a/ODK.Web.Razor/Views/Shared/Admin/Members/_MembersContent.cshtml
+++ b/ODK.Web.Razor/Views/Shared/Admin/Members/_MembersContent.cshtml
@@ -163,6 +163,7 @@
                         @if (!member.Activated)
                         {
                             <form method="post" action="/groups/@Model.Chapter.Id/members/@member.Id/emails/activation/send">
+                                @Html.AntiForgeryToken()
                                 <button data-bs-toggle="tooltip" data-bs-title="Re-send activation email"
                                         class="btn-icon text-primary">
                                     @await Html.PartialAsync("Components/_Icon", new IconViewModel(IconType.EnvelopeSquare))

--- a/ODK.Web.Razor/Views/Shared/Admin/Members/_MembershipSettingsContent.cshtml
+++ b/ODK.Web.Razor/Views/Shared/Admin/Members/_MembershipSettingsContent.cshtml
@@ -14,7 +14,7 @@
         Feature = SiteFeatureType.MemberSubscriptions,
         ContentFunc = 
             @<form action="/groups/@Model.Chapter.Id/membership" method="post">
-                @*@Html.AntiForgeryToken()*@
+                @Html.AntiForgeryToken()
                 @await Html.PartialAsync("Admin/Members/_MembershipSettingsForm", new MembershipSettingsFormViewModel
                 {
                     ApproveNewMembers = membershipSettings?.ApproveNewMembers ?? false,

--- a/ODK.Web.Razor/Views/Shared/Admin/Members/_SubscriptionEditContent.cshtml
+++ b/ODK.Web.Razor/Views/Shared/Admin/Members/_SubscriptionEditContent.cshtml
@@ -5,7 +5,6 @@
 @model SubscriptionAdminPageViewModel
 
 <form method="post">
-    @*@Html.AntiForgeryToken()*@
     @await Html.PartialAsync("Admin/Members/_SubscriptionForm", new SubscriptionFormViewModel
     {
         Amount = Model.Subscription.Amount,

--- a/ODK.Web.Razor/Views/Shared/Admin/Members/_SubscriptionsContent.cshtml
+++ b/ODK.Web.Razor/Views/Shared/Admin/Members/_SubscriptionsContent.cshtml
@@ -99,6 +99,7 @@
                                     @if (!dto.Used)
                                     {
                                         <form method="post" action="/groups/@Model.Chapter.Id/members/subscriptions/@subscription.Id/delete">
+                                            @Html.AntiForgeryToken()
                                             <button data-bs-toggle="tooltip" data-bs-title="Delete" class="btn-icon text-danger"
                                                     onclick="return confirm('Are you sure you want to delete this subscription?');">
                                                 @await Html.PartialAsync("Components/_Icon", new IconViewModel(IconType.Times))

--- a/ODK.Web.Razor/Views/Shared/Admin/Venues/_VenueContent.cshtml
+++ b/ODK.Web.Razor/Views/Shared/Admin/Venues/_VenueContent.cshtml
@@ -14,7 +14,6 @@
 })
 
 <form method="post">
-    @*@Html.AntiForgeryToken()*@
     @await Html.PartialAsync("Admin/Venues/_VenueForm", new VenueFormViewModel
     {
         Address = Model.Venue.Address,

--- a/ODK.Web.Razor/Views/Shared/Admin/Venues/_VenueCreateContent.cshtml
+++ b/ODK.Web.Razor/Views/Shared/Admin/Venues/_VenueCreateContent.cshtml
@@ -8,7 +8,6 @@
 
 <section class="section">
     <form method="post">
-        @*@Html.AntiForgeryToken()*@
 
         @await Html.PartialAsync("Admin/Venues/_VenueForm", new VenueFormViewModel())
 

--- a/ODK.Web.Razor/Views/Shared/Admin/Venues/_VenuesContent.cshtml
+++ b/ODK.Web.Razor/Views/Shared/Admin/Venues/_VenuesContent.cshtml
@@ -74,6 +74,7 @@
                         @if (!Model.Archived)
                         {
                             <form method="post" action="/groups/@Model.Chapter.Id/venues/@venue.Id/archive">
+                                @Html.AntiForgeryToken()
                                 <button type="submit" class="btn btn-icon">
                                     <span data-bs-toggle="tooltip" data-bs-title="Archive">
                                         @await Html.PartialAsync("Components/_Icon", new IconViewModel(IconType.Archive))
@@ -84,6 +85,7 @@
                         else
                         {
                             <form method="post" action="/groups/@Model.Chapter.Id/venues/@venue.Id/restore">
+                                @Html.AntiForgeryToken()
                                 <button type="submit" class="btn btn-icon">
                                     <span data-bs-toggle="tooltip" data-bs-title="Restore">
                                         @await Html.PartialAsync("Components/_Icon", new IconViewModel(IconType.Undo))

--- a/ODK.Web.Razor/Views/Shared/Chapters/SiteAdmin/_ChapterPaymentSettingsContent.cshtml
+++ b/ODK.Web.Razor/Views/Shared/Chapters/SiteAdmin/_ChapterPaymentSettingsContent.cshtml
@@ -11,7 +11,6 @@
 <h2 class="d-none d-md-block">Payment settings</h2>
 
 <form method="post">
-    @*@Html.AntiForgeryToken()*@
     @await Html.PartialAsync("Chapters/siteadmin/_PaymentSettingsForm", new PaymentSettingsFormViewModel
     {
         CurrencyOptions = Model.Currencies,

--- a/ODK.Web.Razor/Views/Shared/Chapters/SiteAdmin/_RedirectContent.cshtml
+++ b/ODK.Web.Razor/Views/Shared/Chapters/SiteAdmin/_RedirectContent.cshtml
@@ -4,7 +4,6 @@
 <h2 class="d-none d-md-block">Redirect</h2>
 
 <form method="post">
-    @*@Html.AntiForgeryToken()*@
 
     <div class="form-group mb-3">
         <label class="form-label" for="redirecturl">Redirect URL</label>

--- a/ODK.Web.Razor/Views/Shared/Contact/_ContactContent.cshtml
+++ b/ODK.Web.Razor/Views/Shared/Contact/_ContactContent.cshtml
@@ -11,7 +11,7 @@
 @if (!Model.Sent)
 {
     <form action="/Contact" method="post">
-        @*@Html.AntiForgeryToken()*@
+        @Html.AntiForgeryToken()
         @await Html.PartialAsync("Contact/_ContactForm", new ContactFormViewModel())
         <button class="btn btn-primary">Send</button>
     </form>

--- a/ODK.Web.Razor/Views/Shared/Conversations/_ConversationContent.cshtml
+++ b/ODK.Web.Razor/Views/Shared/Conversations/_ConversationContent.cshtml
@@ -14,6 +14,7 @@
         {
             <div class="alert alert-info mb-3">
                 <form method="post" action="/conversations/@Model.Conversation.Id/restore">
+                    @Html.AntiForgeryToken()
                     <div class="d-flex align-items-center gap-2">
                         <span>Archived @Model.Conversation.ArchivedUtc.Value.ToRelativeTime(Model.TimeZone).</span>
                         <button class="btn btn-link" type="submit">Restore</button>
@@ -40,7 +41,7 @@
                 BodyContentFunc = 
                     @<div>
                         <form action="/conversations/@Model.Conversation.Id/reply" method="post">
-                            @*@Html.AntiForgeryToken()*@
+                            @Html.AntiForgeryToken()
                             @await Html.PartialAsync("Conversations/_ConversationReplyForm", new ChapterConversationReplyFormViewModel())
                             
                             <div class="d-flex">
@@ -61,6 +62,7 @@
                         @if (Model.Conversation.ArchivedUtc == null)
                         {
                             <form id="archive-conversation-form" method="post" action="/conversations/@Model.Conversation.Id/archive">
+                                @Html.AntiForgeryToken()
                             </form>
                         }                        
                     </div>

--- a/ODK.Web.Razor/Views/Shared/Conversations/_ConversationsContent.cshtml
+++ b/ODK.Web.Razor/Views/Shared/Conversations/_ConversationsContent.cshtml
@@ -97,6 +97,7 @@
                                 @if (!Model.Archived)
                                 {
                                     <form action="/conversations/@dto.Conversation.Id/archive" method="post">
+                                        @Html.AntiForgeryToken()
                                         <button type="submit" class="btn btn-icon"
                                                 data-bs-toggle="tooltip" data-bs-title="Archive">
                                             @await Html.PartialAsync("Components/_Icon", new IconViewModel(IconType.Archive))
@@ -106,6 +107,7 @@
                                 else
                                 {
                                     <form action="/conversations/@dto.Conversation.Id/restore" method="post">
+                                        @Html.AntiForgeryToken()
                                         <button type="submit" class="btn btn-icon"
                                                 data-bs-toggle="tooltip" data-bs-title="Restore">
                                             @await Html.PartialAsync("Components/_Icon", new IconViewModel(IconType.Undo))
@@ -129,7 +131,7 @@
             Body = 
                 @<div>
                     <form action="/groups/@Model.Chapter.Id/conversations" method="post">
-                        @*@Html.AntiForgeryToken()*@
+                        @Html.AntiForgeryToken()
                         @await Html.PartialAsync("Contact/_ConversationForm", new ConversationFormViewModel())
                         <button class="btn btn-primary">Send</button>
                     </form>
@@ -141,7 +143,7 @@ else
 {
     <section class="section mt-3">
         <form action="/groups/@Model.Chapter.Id/conversations" method="post">
-            @*@Html.AntiForgeryToken()*@
+            @Html.AntiForgeryToken()
             @await Html.PartialAsync("Contact/_ConversationForm", new ConversationFormViewModel())
             <button class="btn btn-primary">Send</button>
         </form>

--- a/ODK.Web.Razor/Views/Shared/Events/_EventContent.cshtml
+++ b/ODK.Web.Razor/Views/Shared/Events/_EventContent.cshtml
@@ -66,6 +66,7 @@
             </div>
             <div class="collapse" id="comment-reply-@comment.Id">
                 <form action="/groups/@Model.Chapter.Id/events/@Model.Event.Id/comments" method="post">
+                    @Html.AntiForgeryToken()
                     @await Html.PartialAsync("Events/_EventCommentForm", new EventCommentFormViewModel
                     {
                         Parent  = comment.Id,
@@ -79,6 +80,7 @@
 
     <div>
         <form action="/groups/@Model.Chapter.Id/events/@Model.Event.Id/comments" method="post">
+            @Html.AntiForgeryToken()
             @await Html.PartialAsync("Events/_EventCommentForm", new EventCommentFormViewModel
             {
                 Text = ""

--- a/ODK.Web.Razor/Views/Shared/Events/_EventRSVP.cshtml
+++ b/ODK.Web.Razor/Views/Shared/Events/_EventRSVP.cshtml
@@ -22,7 +22,7 @@
                 if (Model.Event.RsvpDeadlinePassed)
                 {                    
                     <form action="/events/@Model.Event.Id/rsvp" method="post">
-                        @*@Html.AntiForgeryToken()*@
+                        @Html.AntiForgeryToken()
                         <input type="hidden" name="responseType" value="@EventResponseType.No" />
                         <button class="btn btn-danger" onclick="return confirm('Are you sure you want to cancel your RSVP? This action cannot be undone');">
                             Cancel RSVP
@@ -37,6 +37,7 @@
                             var active = responseType == Model.MemberResponse;
                             
                             <form action="/events/@Model.Event.Id/rsvp" method="post">
+                                @Html.AntiForgeryToken()
                                 @await Html.PartialAsync("Events/_EventResponseIcon", new EventResponseIconViewModel
                                 {
                                     Active = active,
@@ -53,6 +54,7 @@
                 if (!Model.IsOnWaitlist)
                 {
                     <form action="/events/@Model.Event.Id/wait-list" method="post">
+                        @Html.AntiForgeryToken()
                         <button class="btn btn-primary btn-sm">
                             Join waiting list
                         </button>
@@ -62,6 +64,7 @@
                 {
                     <div>You're on the waiting list</div>
                     <form action="/events/@Model.Event.Id/wait-list/leave" method="post">
+                        @Html.AntiForgeryToken()
                         <button class="btn btn-danger btn-sm" onclick="return confirm('Are you sure you want to leave the waiting list?');">
                             Leave
                         </button>

--- a/ODK.Web.Razor/Views/Shared/Events/_EventResponseIcon.cshtml
+++ b/ODK.Web.Razor/Views/Shared/Events/_EventResponseIcon.cshtml
@@ -35,7 +35,7 @@
 }
 else
 {
-    @*@Html.AntiForgeryToken()*@
+    @Html.AntiForgeryToken()
     @Html.HiddenFor(x => x.ResponseType)
 
     <button type="submit" class="btn-icon @string.Join(' ', classes)">

--- a/ODK.Web.Razor/Views/Shared/Groups/_GroupContactContent.cshtml
+++ b/ODK.Web.Razor/Views/Shared/Groups/_GroupContactContent.cshtml
@@ -14,7 +14,7 @@
     </p>
 
     <form action="/groups/@Model.Chapter.Id/contact" method="post">
-        @*@Html.AntiForgeryToken()*@
+        @Html.AntiForgeryToken()
         @await Html.PartialAsync("Contact/_ContactForm", new ContactFormViewModel())
         <button class="btn btn-primary">Send</button>
     </form>

--- a/ODK.Web.Razor/Views/Shared/Groups/_GroupEditContent.cshtml
+++ b/ODK.Web.Razor/Views/Shared/Groups/_GroupEditContent.cshtml
@@ -21,6 +21,7 @@ else if (!Model.Chapter.IsPublished())
 {
     <section class="section--admin">
         <form action="/groups/@Model.Chapter.Id/publish" method="post">
+            @Html.AntiForgeryToken()
             <button class="btn btn-success">Publish</button>
         </form>
     </section>

--- a/ODK.Web.Razor/Views/Shared/Groups/_GroupJoinContent.cshtml
+++ b/ODK.Web.Razor/Views/Shared/Groups/_GroupJoinContent.cshtml
@@ -34,7 +34,6 @@
 
 <section class="section">
     <form method="post">
-        @*@Html.AntiForgeryToken()*@
         @await Html.PartialAsync("Account/_ChapterProfileForm", new ChapterProfileFormViewModel
         {
             ChapterName = "",

--- a/ODK.Web.Razor/Views/Shared/Groups/_GroupProfileContent.cshtml
+++ b/ODK.Web.Razor/Views/Shared/Groups/_GroupProfileContent.cshtml
@@ -17,7 +17,7 @@
         <h3>My profile</h3>
         <section class="section">
             <form action="/groups/@Model.Chapter.Id/profile" method="post">
-                @*@Html.AntiForgeryToken()*@
+                @Html.AntiForgeryToken()
                 @await Html.PartialAsync("Account/_ChapterProfileForm", new ChapterProfileFormViewModel
                 {
                     ChapterName = Model.Chapter.GetDisplayName(Model.Platform),

--- a/ODK.Web.Razor/Views/Shared/Pricing/_SubscriptionPrice.cshtml
+++ b/ODK.Web.Razor/Views/Shared/Pricing/_SubscriptionPrice.cshtml
@@ -44,7 +44,7 @@
                 @Model.Currency.ToAmountString(Model.Amount)/@periodUnit
             </p>
             <form action="/account/subscription/confirm" method="post">
-                @*@Html.AntiForgeryToken()*@
+                @Html.AntiForgeryToken()
                 @await Html.PartialAsync("Payments/_PaymentSubscriptionForm", new PaymentSubscriptionFormViewModel
                 {
                     CurrencyCode = Model.Currency.Code,

--- a/ODK.Web.Razor/Views/Shared/SiteAdmin/_EmailContent.cshtml
+++ b/ODK.Web.Razor/Views/Shared/SiteAdmin/_EmailContent.cshtml
@@ -2,7 +2,6 @@
 @model ODK.Web.Razor.Models.SiteAdmin.EmailContentViewModel
 
 <form method="post">
-    @*@Html.AntiForgeryToken()*@
     
     <div class="form-check mb-3">
         @Html.CheckBox("overridable", Model.Email.Overridable, new { @class = "form-check-input" })
@@ -26,4 +25,5 @@
 
 <form method="post" action="/siteadmin/emails/@Model.Email.Type/send/test"
       id="send-test-form">
+    @Html.AntiForgeryToken()
 </form>

--- a/ODK.Web.Razor/Views/Shared/SiteAdmin/_EmailsContent.cshtml
+++ b/ODK.Web.Razor/Views/Shared/SiteAdmin/_EmailsContent.cshtml
@@ -13,7 +13,7 @@
 <section class="section--admin">
     <h2>Settings</h2>
     <form action="/siteadmin/emails/settings" method="post">
-        @*@Html.AntiForgeryToken()*@
+        @Html.AntiForgeryToken()
         @await Html.PartialAsync("SiteAdmin/_EmailSettingsForm", new SiteEmailSettingsViewModel
         {
             FromEmailAddress = settings.FromEmailAddress,

--- a/ODK.Web.Razor/Views/Shared/SiteAdmin/_ErrorsContent.cshtml
+++ b/ODK.Web.Razor/Views/Shared/SiteAdmin/_ErrorsContent.cshtml
@@ -35,7 +35,7 @@
                         </td>
                         <td>
                             <form method="post" action="/siteadmin/Errors/@error.Id/Delete">
-                                @*@Html.AntiForgeryToken()*@
+                                @Html.AntiForgeryToken()
                                 <button data-bs-toggle="tooltip" data-bs-title="Delete" class="btn-icon text-danger">
                                     @await Html.PartialAsync("Components/_Icon", new IconViewModel(IconType.Times))
                                 </button>

--- a/ODK.Web.Razor/Views/Shared/SiteAdmin/_FeatureContent.cshtml
+++ b/ODK.Web.Razor/Views/Shared/SiteAdmin/_FeatureContent.cshtml
@@ -4,7 +4,6 @@
 @model ODK.Web.Razor.Models.SiteAdmin.FeatureContentViewModel
 
 <form method="post">
-    @*@Html.AntiForgeryToken()*@
     @await Html.PartialAsync("SiteAdmin/_FeatureForm", new FeatureFormViewModel
     {
         Description = Model.Feature.Description,

--- a/ODK.Web.Razor/Views/Shared/SiteAdmin/_FeatureCreateContent.cshtml
+++ b/ODK.Web.Razor/Views/Shared/SiteAdmin/_FeatureCreateContent.cshtml
@@ -2,7 +2,6 @@
 
 <h2>Create feature notification</h2>
 <form method="post">
-    @*@Html.AntiForgeryToken()*@
     @await Html.PartialAsync("SiteAdmin/_FeatureForm", new FeatureFormViewModel())
     <button class="btn btn-primary">Create</button>
 </form>

--- a/ODK.Web.Razor/Views/Shared/SiteAdmin/_FeaturesContent.cshtml
+++ b/ODK.Web.Razor/Views/Shared/SiteAdmin/_FeaturesContent.cshtml
@@ -41,7 +41,7 @@
                     <td>@feature.CreatedUtc.ToString("yyyy-MM-dd")</td>
                     <td>
                         <form action="/siteadmin/features/@feature.Id/delete" method="post">
-                            @*@Html.AntiForgeryToken()*@
+                            @Html.AntiForgeryToken()
                             <button class="btn-icon text-danger" onclick="return confirm('Are you sure you want to delete this feature?');">
                                 @await Html.PartialAsync("Components/_Icon", new IconViewModel(IconType.Times))
                             </button>

--- a/ODK.Web.Razor/Views/Shared/SiteAdmin/_InstagramContent.cshtml
+++ b/ODK.Web.Razor/Views/Shared/SiteAdmin/_InstagramContent.cshtml
@@ -5,7 +5,7 @@
 <h2 class="d-none d-md-block">Instagram</h2>
 
 <form method="post" action="/groups/@Model.Id/siteadmin/instagram/scrape">
-    @*@Html.AntiForgeryToken()*@
+    @Html.AntiForgeryToken()
     <button class="btn btn-secondary">Scrape</button>
 </form>
 <p class="text-muted mt-3">

--- a/ODK.Web.Razor/Views/Shared/SiteAdmin/_MessageContent.cshtml
+++ b/ODK.Web.Razor/Views/Shared/SiteAdmin/_MessageContent.cshtml
@@ -84,7 +84,7 @@
             <button type="button" class="btn btn-link" data-bs-toggle="collapse" data-bs-target="#mark-replied">Already replied?</button>
             <div class="collapse" id="mark-replied">
                 <form action="/siteadmin/messages/@Model.Message.Id/replied" method="post">
-                    @*@Html.AntiForgeryToken()*@
+                    @Html.AntiForgeryToken()
                     <button class="btn btn-primary">Set message as replied</button>
                 </form>
             </div>            
@@ -92,7 +92,7 @@
     }    
 
     <form action="/siteadmin/messages/@Model.Message.Id/reply" method="post">
-        @*@Html.AntiForgeryToken()*@
+        @Html.AntiForgeryToken()
         @await Html.PartialAsync("SiteAdmin/_MessageForm", new MessageReplyFormViewModel
         {
             Message = ""

--- a/ODK.Web.Razor/Views/Shared/SiteAdmin/_MessagesContent.cshtml
+++ b/ODK.Web.Razor/Views/Shared/SiteAdmin/_MessagesContent.cshtml
@@ -19,6 +19,7 @@
     {
         <div class="my-3">
             <form action="/siteadmin/messages/spam/delete" method="post">
+                @Html.AntiForgeryToken()
                 <button type="submit" class="btn btn-primary" onclick="return confirm('Are you sure you want to delete all spam messages?');">
                     Delete all
                 </button>
@@ -59,7 +60,7 @@
                     </td>
                     <td>
                         <form method="post" action="/siteadmin/messages/@message.Id/delete">
-                            @*@Html.AntiForgeryToken()*@
+                            @Html.AntiForgeryToken()
                             <button data-bs-toggle="tooltip" data-bs-title="Delete" class="btn-icon text-danger"
                                     onclick="return confirm('Are you sure you want to delete this message?');">
                                     @await Html.PartialAsync("Components/_Icon", new IconViewModel(IconType.Times))

--- a/ODK.Web.Razor/Views/Shared/SiteAdmin/_PaymentsContent.cshtml
+++ b/ODK.Web.Razor/Views/Shared/SiteAdmin/_PaymentsContent.cshtml
@@ -50,6 +50,7 @@
                                 else
                                 {
                                     <form action="/siteadmin/payments/@paymentSetting.Id/activate" method="post">
+                                        @Html.AntiForgeryToken()
                                         <button class="btn btn-primary">Activate</button>
                                     </form>
                                 }

--- a/ODK.Web.Razor/Views/Shared/SiteAdmin/_SiteAdminAdminMembersContent.cshtml
+++ b/ODK.Web.Razor/Views/Shared/SiteAdmin/_SiteAdminAdminMembersContent.cshtml
@@ -29,6 +29,7 @@
                         else
                         {
                             <form action="/groups/@Model.Chapter.Id/owner" method="post">
+                                @Html.AntiForgeryToken()
                                 @Html.Hidden("memberId", adminMember.MemberId)
                                 <button class="btn btn-icon" data-bs-toggle="tooltip" data-bs-title="Set as owner">
                                     @await Html.PartialAsync("Components/_Icon", new IconViewModel(IconType.StarOutline)
@@ -41,6 +42,7 @@
                     </td>
                     <td>
                         <form action="/groups/@Model.Chapter.Id/members/@adminMember.MemberId/visibility" method="post">
+                            @Html.AntiForgeryToken()
                             @if (adminMember.Member.Visible(Model.Chapter.Id))
                             {
                                 @Html.Hidden("visible", false)

--- a/ODK.Web.Razor/Views/Shared/SiteAdmin/_SiteAdminGroupContent.cshtml
+++ b/ODK.Web.Razor/Views/Shared/SiteAdmin/_SiteAdminGroupContent.cshtml
@@ -22,7 +22,6 @@
 <h2>@chapterName</h2>
 
 <form method="post">
-    @*@Html.AntiForgeryToken()*@
 
     @await Html.PartialAsync("SiteAdmin/_SiteAdminGroupContentForm", new SiteAdminChapterFormViewModel
     {

--- a/ODK.Web.Razor/Views/Shared/SiteAdmin/_SiteAdminGroupsContent.cshtml
+++ b/ODK.Web.Razor/Views/Shared/SiteAdmin/_SiteAdminGroupsContent.cshtml
@@ -96,11 +96,11 @@
                                 <td>
                                     <div class="button-container">
                                         <form action="/siteadmin/groups/@chapter.Id/approve" method="post">
-                                            @*@Html.AntiForgeryToken()*@
+                                            @Html.AntiForgeryToken()
                                             <button class="btn btn-success btn-sm">Approve</button>
                                         </form>
                                         <form action="/siteadmin/groups/@chapter.Id/delete" method="post">
-                                            @*@Html.AntiForgeryToken()*@
+                                            @Html.AntiForgeryToken()
                                             <button class="btn btn-danger btn-sm"
                                                     onclick="return confirm('Are you sure you want to delete this group?');">
                                                 Delete

--- a/ODK.Web.Razor/Views/Shared/SiteAdmin/_SiteAdminTopicContent.cshtml
+++ b/ODK.Web.Razor/Views/Shared/SiteAdmin/_SiteAdminTopicContent.cshtml
@@ -22,7 +22,7 @@
 
 <section class="section">
     <form action="/siteadmin/topics/@Model.Topic.Id" method="post">
-        @*@Html.AntiForgeryToken()*@
+        @Html.AntiForgeryToken()
         
         @await Html.PartialAsync("SiteAdmin/_SiteAdminTopicForm", new TopicFormViewModel
         {

--- a/ODK.Web.Razor/Views/Shared/SiteAdmin/_SiteAdminTopicsContent.cshtml
+++ b/ODK.Web.Razor/Views/Shared/SiteAdmin/_SiteAdminTopicsContent.cshtml
@@ -17,7 +17,7 @@
     <h2>New topics</h2>
     <section class="section section--admin">
         <form action="/siteadmin/topics/approve" method="post">
-            @*@Html.AntiForgeryToken()*@
+            @Html.AntiForgeryToken()
             @await Html.PartialAsync("SiteAdmin/_NewTopicsForm", new NewTopicsFormViewModel
             {
                 Chapters = Model.NewChapterTopics
@@ -68,7 +68,7 @@
                         }
 
                         <form action="/siteadmin/topics" method="post">
-                            @*@Html.AntiForgeryToken()*@
+                            @Html.AntiForgeryToken()
                             @Html.Hidden("TopicGroupId", topicGroup.Id.ToString())
 
                             <div class="input-group mt-3">
@@ -84,7 +84,7 @@
 <section class="mt-3">
     <h3>Add topic group</h3>
     <form action="/siteadmin/topic-groups" method="post">
-        @*@Html.AntiForgeryToken()*@
+        @Html.AntiForgeryToken()
         
         <div class="form-group mb-3">
             <input type="text" class="form-control" name="Name" />            

--- a/ODK.Web.Razor/Views/Shared/SiteAdmin/_SiteSubscriptionsContent.cshtml
+++ b/ODK.Web.Razor/Views/Shared/SiteAdmin/_SiteSubscriptionsContent.cshtml
@@ -53,6 +53,7 @@
                                 @if (subscription.Enabled)
                                 {
                                     <form action="/siteadmin/subscriptions/@subscription.Id/disable" method="post">
+                                        @Html.AntiForgeryToken()
                                         <button class="btn btn-icon" 
                                                 data-bs-toggle="tooltip" data-bs-title="Disable">
                                             @await Html.PartialAsync("Components/_Icon", new IconViewModel(IconType.CheckCircle)
@@ -65,6 +66,7 @@
                                 else
                                 {
                                     <form action="/siteadmin/subscriptions/@subscription.Id/enable" method="post">
+                                        @Html.AntiForgeryToken()
                                         <button class="btn btn-icon"
                                                 data-bs-toggle="tooltip" data-bs-title="Enable">
                                             @await Html.PartialAsync("Components/_Icon", new IconViewModel(IconType.TimesCircleOutline)
@@ -120,7 +122,7 @@
                                 else
                                 {
                                     <form action="/siteadmin/subscriptions/@subscription.Id/default" method="post">
-                                        @*@Html.AntiForgeryToken()*@
+                                        @Html.AntiForgeryToken()
                                         <button class="btn btn-primary btn-sm">Set default</button>
                                     </form>
                                 }

--- a/ODK.Web.Razor/Views/Shared/SiteAdmin/_SubscriptionContent.cshtml
+++ b/ODK.Web.Razor/Views/Shared/SiteAdmin/_SubscriptionContent.cshtml
@@ -10,7 +10,7 @@
 <section class="section--admin">
     <h2>@Model.Subscription.Name</h2>
     <form action="/siteadmin/Subscriptions/@Model.Subscription.Id" method="post">
-        @*@Html.AntiForgeryToken()*@
+        @Html.AntiForgeryToken()
         @await Html.PartialAsync("SiteAdmin/_SubscriptionForm", new SiteSubscriptionFormViewModel
         {
             Description = Model.Subscription.Description,
@@ -53,7 +53,7 @@
                         <td>@price.ExternalId</td>
                         <td>
                             <form action="/siteadmin/Subscriptions/@Model.Subscription.Id/Prices/@price.Id/Delete" method="post">
-                                @*@Html.AntiForgeryToken()*@
+                                @Html.AntiForgeryToken()
                                 <button data-bs-toggle="tooltip" data-bs-title="Delete" class="btn-icon text-danger"
                                         onclick="return confirm('Are you sure you want to delete this price?');">
                                     @await Html.PartialAsync("Components/_Icon", new IconViewModel(IconType.Times))
@@ -67,7 +67,7 @@
     </div>
     <div class="mt-3">
         <form action="/siteadmin/Subscriptions/@Model.Subscription.Id/Prices" method="post">
-            @*@Html.AntiForgeryToken()*@
+            @Html.AntiForgeryToken()
 
             <div class="form-inline">                
                 @await Html.PartialAsync("SiteAdmin/_SubscriptionPriceForm", new SiteSubscriptionPriceFormViewModel

--- a/ODK.Web.Razor/Views/Shared/SiteAdmin/_SubscriptionCreateContent.cshtml
+++ b/ODK.Web.Razor/Views/Shared/SiteAdmin/_SubscriptionCreateContent.cshtml
@@ -12,7 +12,7 @@
 
 <section class="section">
     <form action="/siteadmin/subscriptions" method="post">
-        @*@Html.AntiForgeryToken()*@
+        @Html.AntiForgeryToken()
         @await Html.PartialAsync("SiteAdmin/_SubscriptionForm", new SiteSubscriptionFormViewModel
         {
             SitePaymentSettingId = sitePaymentSettings.FirstOrDefault(x => x.Active)?.Id,

--- a/ODK.Web.Razor/wwwroot/js/odk.forms.js
+++ b/ODK.Web.Razor/wwwroot/js/odk.forms.js
@@ -100,7 +100,8 @@ window.odk.forms = window.odk.forms || {};
                 const url = $input.getAttribute('data-input-change-url')
                     .replace('{value}', value);
                 await fetch(url, {
-                    method: 'POST'
+                    method: 'POST',
+                    headers: window.odk.antiforgeryHeaders()
                 });
             });
         });

--- a/ODK.Web.Razor/wwwroot/js/odk.js
+++ b/ODK.Web.Razor/wwwroot/js/odk.js
@@ -17,6 +17,12 @@
     window.odk.utils = window.odk.utils || {};
     window.odk.utils.bindTooltips = bindTooltips;
 
+    // Headers for AJAX POSTs so they carry the antiforgery token (from the layout meta tag).
+    window.odk.antiforgeryHeaders = function () {
+        const token = document.querySelector('meta[name="request-verification-token"]')?.content;
+        return token ? { 'RequestVerificationToken': token } : {};
+    };
+
     function bindAttachTo() {
         const $elements = document.querySelectorAll('[data-attach-to]');
         $elements.forEach($element => {
@@ -102,7 +108,8 @@
             const url = `/Account/FeatureTips/${encodeURIComponent(name)}/Hide`;
 
             fetch(url, {
-                method: 'POST'
+                method: 'POST',
+                headers: window.odk.antiforgeryHeaders()
             }).then(() => {
                 target.removeAttribute('data-feature-hidetip');
 

--- a/ODK.Web.Razor/wwwroot/js/odk.notifications.js
+++ b/ODK.Web.Razor/wwwroot/js/odk.notifications.js
@@ -10,7 +10,7 @@
                 const $notification = $button.closest('[data-notification]');
 
                 const url = $button.getAttribute('data-notification-dismiss');
-                fetch(url, { method: 'POST' })
+                fetch(url, { method: 'POST', headers: window.odk.antiforgeryHeaders() })
                     .then(() => {
                         const tooltip = bootstrap.Tooltip.getOrCreateInstance($button);
                         tooltip.dispose();
@@ -28,7 +28,7 @@
                 e.preventDefault();
 
                 const url = $button.getAttribute('data-url');
-                fetch(url, { method: 'POST' })
+                fetch(url, { method: 'POST', headers: window.odk.antiforgeryHeaders() })
                     .then(() => {
                         const $notifications = $container.querySelectorAll('[data-notification]');
                         $notifications.forEach($notification => $notification.remove());

--- a/README.md
+++ b/README.md
@@ -23,3 +23,48 @@ The batch file spawns two tabs: the `dotnet` process in the main tab and a sass 
 `.css` files are compiled into `wwwroot/css` from the `.scss` files in `wwwroot/scss`.
 
 To compile, run `npm run build:css`. The compilation script also runs when the app is run from one of the batch files.
+
+## Antiforgery (CSRF)
+
+Antiforgery validation is enabled globally: Razor Page POST handlers validate by default, and MVC
+controllers validate via the `AutoValidateAntiforgeryTokenAttribute` filter registered in `Program.cs`.
+Every state-changing POST must therefore carry a valid antiforgery token, so **every `<form method="post">`
+needs a token in the rendered HTML**. There must be exactly **one** token per form — zero fails validation,
+and two (duplicate) tokens also fail (the values are comma-joined and no longer deserialize).
+
+### When a form needs an explicit `@Html.AntiForgeryToken()`
+
+The Form Tag Helper decides whether it auto-emits a hidden token field:
+
+| Form | Tag Helper auto-emits? | What to write |
+|---|---|---|
+| `<form method="post">` (no `action`) | **Yes** | Nothing — do **not** add `@Html.AntiForgeryToken()` (that would duplicate it). |
+| `<form method="post" asp-controller/asp-page/asp-action=...>` | **Yes** | Nothing — the token is auto-emitted. |
+| `<form method="post" action="/some/url">` (literal `action`) | **No** | Add `@Html.AntiForgeryToken()` as the first child of the form. |
+
+Rule of thumb: **a literal `action` attribute suppresses the auto-token, so those forms — and only those —
+need an explicit `@Html.AntiForgeryToken()`.** This project posts most mutating forms to controller
+endpoints via a literal `action` (the Post/Redirect/Get split), so most forms carry an explicit token.
+
+### AJAX POSTs
+
+A `fetch(..., { method: 'POST' })` has no form field, so it must send the token as a header. The layout
+renders it in a `<meta name="request-verification-token">` tag; read it with the shared helper and spread
+it into the request:
+
+```js
+fetch(url, { method: 'POST', headers: window.odk.antiforgeryHeaders() })
+```
+
+The configured header name is `RequestVerificationToken` (see `AddAntiforgery` in `Program.cs`).
+
+### Exemptions
+
+Only endpoints that are **not** first-party browser POSTs are exempt, via `[IgnoreAntiforgeryToken]`:
+
+- `WebhooksController` (Stripe / Brevo) — authenticated by provider signature/secret.
+- `ScheduledTasksController` (cron) — authenticated by the ScheduledTasks API key.
+- `AccountController.GoogleSiteLogin` / `GoogleChapterLogin` — the token is posted by Google Identity JS,
+  not a first-party form.
+
+Do not add new exemptions for ordinary forms; fix the token instead.


### PR DESCRIPTION
Antiforgery was globally disabled after some POSTs started failing; the root cause was never investigated. Re-enable it properly:

- Remove the IgnoreAntiforgeryToken Razor Pages convention (restoring the built-in page-handler validation) and add AutoValidateAntiforgeryToken as a global MVC controller filter.
- Give every literal-action <form> an explicit @Html.AntiForgeryToken() and drop redundant tokens from tag-helper forms, so each form renders exactly one token (zero and duplicate tokens both fail validation).
- Deliver the token to AJAX POSTs via a request-verification-token meta tag + window.odk.antiforgeryHeaders() helper; header name configured as RequestVerificationToken.
- Exempt non-first-party POSTs via [IgnoreAntiforgeryToken]: Stripe/Brevo webhooks (signature-authed), scheduled tasks (API-key-authed), and Google Identity login (token posted by Google JS).
- Document the form-token rules in README.md.