### PR TITLE
(git): block direct commits to master

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,7 @@
 # rewrite it to CRLF (which caused "LF will be replaced by CRLF" warnings and
 # noisy diffs on every recompile).
 ODK.Web.Razor/wwwroot/css/*.css text eol=lf
+
+# Git hooks are shell scripts run via /bin/sh - keep them LF so the shebang isn't
+# broken by CRLF on Windows checkouts.
+.githooks/** text eol=lf

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,17 @@
+#!/bin/sh
+# Block direct commits to the mainline branch. Work lands via a feature branch + PR (see CLAUDE.md).
+# Enable per clone with: git config core.hooksPath .githooks
+
+branch="$(git symbolic-ref --short HEAD 2>/dev/null)"
+
+case "$branch" in
+    master|main)
+        echo "✖ Direct commits to '$branch' are blocked." >&2
+        echo "  Create a feature branch first:" >&2
+        echo "      git switch -c my-branch" >&2
+        echo "  then commit there. (Override with 'git commit --no-verify' only if you truly mean to.)" >&2
+        exit 1
+        ;;
+esac
+
+exit 0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,20 @@ Tests: `ODK.Core.Tests`, `ODK.Services.Tests`, `ODK.Services.Integrations.Tests`
 
 Project defaults: `net10.0`, nullable enabled, implicit usings enabled.
 
+## Git workflow
+
+**Never make changes or commit while `master` is the active branch.** `master` is the mainline that
+deploys to prod — all work lands via a branch and PR. Before editing anything, check the current branch;
+if it's `master`, create a feature branch first (`git switch -c <branch>`) and do the work there. This
+applies to every change, however small (a one-line fix, a doc tweak, a migration).
+
+A `pre-commit` hook enforces this — it rejects commits made on `master`. It lives in the tracked
+`.githooks/` directory; enable it once per clone with:
+
+```
+git config core.hooksPath .githooks
+```
+
 ## Database migrations
 
 EF Core migrations live in `ODK.Data.EntityFramework.Migrations` and are run explicitly (never on app


### PR DESCRIPTION
Add a tracked pre-commit hook (.githooks/pre-commit) that rejects commits made on master/main, and document the branch-first workflow + one-time `git config core.hooksPath .githooks` setup in CLAUDE.md.